### PR TITLE
s/algorithm/algorithms

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -414,7 +414,7 @@ consists of a SignatureSchemeList (defined in {{RFC8446}}):
 
 ~~~~~~~~~~
    struct {
-     SignatureScheme supported_signature_algorithm<2..2^16-2>;
+     SignatureScheme supported_signature_algorithms<2..2^16-2>;
    } SignatureSchemeList;
 ~~~~~~~~~~
 


### PR DESCRIPTION
s/algorithm/algorithms

Section 4.1.1:  Should an "s" be added to
"supported_signature_algorithm" per RFC 8446?  
If this is not the case, is the singular form
be defined elsewhere?

Original:
 SignatureScheme supported_signature_algorithm<2..2^16-2>;

Perhaps:
 SignatureScheme supported_signature_algorithms<2..2^16-2>;