### PR TITLE
Certificate Transparency

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -556,7 +556,7 @@ This document registers the "delegated_credential" extension in the
 extension has been assigned code point 34.  The IANA registry
 lists this extension as "Recommended" (i.e., "Y") and indicates that
 it may appear in the ClientHello (CH), CertificateRequest (CR),
-or Certificate (CT) messages in (D)TLS 1.3 {{RFC8446}} {{RFC9147}}.
+or Certificate Transparency (CT) messages in (D)TLS 1.3 {{RFC8446}} {{RFC9147}}.
 Additionally, the "DTLS-Only" column is assigned the value "N".
 
 This document also defines an ASN.1 module for the DelegationUsage


### PR DESCRIPTION
Section 6: Should "Certificate (CT)" be "Certificate Transparency (CT)"?