### PR TITLE
s/1.3.5.1.5.5.7.0/1.3.6.1.5.5.7.0?

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -562,7 +562,7 @@ Additionally, the "DTLS-Only" column is assigned the value "N".
 This document also defines an ASN.1 module for the DelegationUsage
 certificate extension in {{module}}.  IANA has registered value 95 for
 "id-mod-delegated-credential-extn" in the "SMI Security for PKIX Module
-Identifier" (1.3.5.1.5.5.7.0) registry.  An OID for the DelegationUsage certificate extension
+Identifier" (1.3.6.1.5.5.7.0) registry.  An OID for the DelegationUsage certificate extension
 is not needed, as it is already assigned to the extension from
 Cloudflare's IANA Private Enterprise Number (PEN) arc.
 


### PR DESCRIPTION
We believe "1.3.5.1.5.5.7.0" should be "1.3.6.1.5.5.7.0" per <https://www.iana.org/assignments/smi-numbers/>,
<http://www.oid-info.com/cgi-bin/display?oid=1.3.6.1.5.5.7.0&a=display> ("1.3.5.1.5.5.7.0" yielded an error), and a portion of the OID definition in Appendix A.  Please review.