### PR TITLE
commas after "message"

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -435,7 +435,7 @@ CertificateEntry of its end-entity certificate; the client SHOULD ignore
 delegated credentials sent as extensions to any other certificate.
 
 The algorithm field MUST be of a type advertised by the client in the
-"signature_algorithms" extension of the ClientHello message and
+"signature_algorithms" extension of the ClientHello message, and
 the dc_cert_verify_algorithm field MUST be of a
 type advertised by the client in the SignatureSchemeList and is
 considered not valid otherwise.  Clients that receive non-valid delegated
@@ -461,7 +461,7 @@ CertificateEntry of its end-entity certificate; the server SHOULD ignore
 delegated credentials sent as extensions to any other certificate.
 
 The algorithm field MUST be of a type advertised by the server
-in the "signature_algorithms" extension of the CertificateRequest message
+in the "signature_algorithms" extension of the CertificateRequest message,
 and the dc_cert_verify_algorithm field MUST be of a type
 advertised by the server in the SignatureSchemeList
 and is considered not valid otherwise.  Servers that receive non-valid

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -437,8 +437,8 @@ delegated credentials sent as extensions to any other certificate.
 The algorithm field MUST be of a type advertised by the client in the
 "signature_algorithms" extension of the ClientHello message, and
 the dc_cert_verify_algorithm field MUST be of a
-type advertised by the client in the SignatureSchemeList and is
-considered not valid otherwise.  Clients that receive non-valid delegated
+type advertised by the client in the SignatureSchemeList; otherwise, the credential is
+considered not valid.  Clients that receive non-valid delegated
 credentials MUST terminate the connection with an "illegal_parameter"
 alert.
 

--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -463,8 +463,8 @@ delegated credentials sent as extensions to any other certificate.
 The algorithm field MUST be of a type advertised by the server
 in the "signature_algorithms" extension of the CertificateRequest message,
 and the dc_cert_verify_algorithm field MUST be of a type
-advertised by the server in the SignatureSchemeList
-and is considered not valid otherwise.  Servers that receive non-valid
+advertised by the server in the SignatureSchemeList; otherwise, the credential is
+considered not valid.  Servers that receive non-valid
 delegated credentials MUST terminate the connection with an
 "illegal_parameter" alert.
 


### PR DESCRIPTION
Sections 4.1.1 and 4.1.2:  As it appears that "and is                                   considered not valid otherwise" refers to the dc_cert_verify_algorithm field and not also to the algorithm field, we suggest adding commas after "message" in these compound sentences.  If this is not correct, does "and is considered not valid otherwise" mean that if the conditions are not met, the types are not valid?