### PR TITLE
References [X.680] and [X.690]

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -38,19 +38,21 @@ author:
 
 normative:
   X.680:
+      target: https://www.itu.int/rec/T-REC-X.680
       title: "Information technology - Abstract Syntax Notation One (ASN.1): Specification of basic notation"
-      date: November 2015
+      date: February 2021
       author:
         org: ITU-T
       seriesinfo:
-        ISO/IEC: 8824-1:2015
+        ISO/IEC: 8824-1:2021
   X.690:
+      target: https://www.itu.int/rec/T-REC-X.690
       title: "Information technology - ASN.1 encoding Rules: Specification of Basic Encoding Rules (BER), Canonical Encoding Rules (CER) and Distinguished Encoding Rules (DER)"
-      date: November 2015
+      date: February 2021
       author:
         org: ITU-T
       seriesinfo:
-        ISO/IEC: 8825-1:2015
+        ISO/IEC: 8825-1:2021
 
 informative:
   XPROT:


### PR DESCRIPTION
Reference listings for [X.680] and [X.690]:
The 2015 versions of these documents are listed as "Superseded" on <https://www.itu.int/rec/T-REC-X.680> and <https://www.itu.int/rec/T-REC-X.690>, and "Withdrawn" (revised by 2021 versions) on <https://www.iso.org/standard/68350.html> and <https://www.iso.org/standard/68345.html>.

Because the ISO/IEC documents are behind a paywall, we have included the ITU-T URLs.  Please note that we would use the ITU-T publication dates (if acceptable), even though the corresponding ISO/IEC documents weren't published until June 2021.