### PR TITLE
Suggestion to use {::boilerplate bcp14-tagged}

### DIFF
--- a/draft-ietf-tls-subcerts.md
+++ b/draft-ietf-tls-subcerts.md
@@ -164,12 +164,7 @@ Back-End: Service with access to a private key
 
 # Conventions and Terminology
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
-"OPTIONAL" in this document are to be interpreted as described in BCP
-14 {{!RFC2119}} {{!RFC8174}} when, and only when, they appear in all
-capitals, as shown here.
-
+{::boilerplate bcp14-tagged}
 
 # Solution Overview
 


### PR DESCRIPTION
We would like to replace the manually entered "key words" boilerplate text with {::boilerplate bcp14-tagged}, to (1) create the proper boilerplate paragraph in the output files and (2) tag all key words in the boilerplate paragraph, and all instances of key words in the document, with <bcp14> tags in XML output.  All key words will be properly bolded in .html and .pdf output files.