### PR TITLE
update-listing-for-Kazuho-Oku-in-acks

### DIFF
--- a/rfc9345.xml
+++ b/rfc9345.xml
@@ -743,7 +743,7 @@ y5S4RfWHIIPjbw==
     <section anchor="acknowledgements">
       <name>Acknowledgements</name>
       <t>Thanks to David Benjamin, Christopher Patton, Kyle Nekritz, Anirudh Ramachandran, Benjamin
-Kaduk, Kazuho Oku, Daniel Kahn Gillmor, Watson Ladd, Robert Merget, Juraj
+Kaduk, 奥 一穂 (Kazuho Oku), Daniel Kahn Gillmor, Watson Ladd, Robert Merget, Juraj
 Somorovsky, and Nimrod Aviram for their discussions, ideas,
 and bugs they have found.</t>
     </section>


### PR DESCRIPTION
issue #19  Updated the display of Kazuho Oku's name in the Ack.s section.