### PR TITLE
xml_define-CA-in-Abstract

### DIFF
--- a/rfc9345.xml
+++ b/rfc9345.xml
@@ -48,7 +48,7 @@
 endpoints and the certification authority can create limitations.  For
 example, the lifetime of certificates, how they may be used, and the
 algorithms they support are ultimately determined by the
-CA.  This document describes a mechanism to
+Certification Authority (CA).  This document describes a mechanism to
 to overcome some of these limitations by enabling operators to
 delegate their own credentials for use in TLS and DTLS without breaking
 compatibility with peers that do not support this specification.</t>


### PR DESCRIPTION
XML file:  Define "CA" (as "Certification Authority") in Abstract.